### PR TITLE
Remove version from Windows Terminal;

### DIFF
--- a/windows/StartI2PdBrowser.bat
+++ b/windows/StartI2PdBrowser.bat
@@ -3,7 +3,9 @@ REM Copyright (c) 2013-2019, The PurpleI2P Project
 REM This file is part of Purple i2pd project and licensed under BSD3
 REM See full license text in LICENSE file at top of project tree
 
-title Starting I2Pd Browser 1.2.8
+FOR /F "tokens=*" %%t IN ('git describe --tags') do (SET version=%%t)
+
+title Starting I2Pd Browser %version%
 set $pause=ping.exe 0.0.0.0 -n
 set $cd=%CD%
 ver| find "6." >nul && set $pause=timeout.exe /t
@@ -42,11 +44,11 @@ rem ==========================================================================
 
 rem ==========================================================================
 rem Процедура EchoWithoutCrLf
-rem 
+rem
 rem %1 : текст для вывода.
 rem ==========================================================================
 :EchoWithoutCrLf
-    
+
     <nul set /p strTemp=%~1
     exit /b 0
 rem ==========================================================================

--- a/windows/StartI2PdBrowser.bat
+++ b/windows/StartI2PdBrowser.bat
@@ -3,9 +3,7 @@ REM Copyright (c) 2013-2019, The PurpleI2P Project
 REM This file is part of Purple i2pd project and licensed under BSD3
 REM See full license text in LICENSE file at top of project tree
 
-FOR /F "tokens=*" %%t IN ('git describe --tags') do (SET version=%%t)
-
-title Starting I2Pd Browser %version%
+title Starting I2Pd Browser
 set $pause=ping.exe 0.0.0.0 -n
 set $cd=%CD%
 ver| find "6." >nul && set $pause=timeout.exe /t

--- a/windows_prebuilt/src/StartI2PdBrowser.bat
+++ b/windows_prebuilt/src/StartI2PdBrowser.bat
@@ -3,9 +3,7 @@ REM Copyright (c) 2013-2019, The PurpleI2P Project
 REM This file is part of Purple i2pd project and licensed under BSD3
 REM See full license text in LICENSE file at top of project tree
 
-FOR /F "tokens=*" %%t IN ('git describe --tags') do (SET version=%%t)
-
-title Starting I2Pd Browser %version%
+title Starting I2Pd Browser
 set $pause=ping.exe 0.0.0.0 -n
 set $cd=%CD%
 ver| find "6." >nul && set $pause=timeout.exe /t

--- a/windows_prebuilt/src/StartI2PdBrowser.bat
+++ b/windows_prebuilt/src/StartI2PdBrowser.bat
@@ -3,7 +3,9 @@ REM Copyright (c) 2013-2019, The PurpleI2P Project
 REM This file is part of Purple i2pd project and licensed under BSD3
 REM See full license text in LICENSE file at top of project tree
 
-title Starting I2Pd Browser 1.2.8
+FOR /F "tokens=*" %%t IN ('git describe --tags') do (SET version=%%t)
+
+title Starting I2Pd Browser %version%
 set $pause=ping.exe 0.0.0.0 -n
 set $cd=%CD%
 ver| find "6." >nul && set $pause=timeout.exe /t
@@ -38,6 +40,6 @@ cd %$cd%
 exit /b 0
 
 :EchoWithoutCrLf
-    
+
     <nul set /p strTemp=%~1
     exit /b 0


### PR DESCRIPTION
- windows/StartI2PdBrowser.bat
- windows_prebuilt/src/StartI2PdBrowser.bat
  - Uses Git to determine current version.
  - Displays the correct version in the startup window.