### PR TITLE
Update Firefox and I2Pd and adjust search engine settings

### DIFF
--- a/linux/build/build
+++ b/linux/build/build
@@ -12,7 +12,7 @@ cd $dir
 
 arch=$(uname -m)
 language=$(echo $LANG | cut -c-5 | sed s/_/-/g)
-version="115.19.0esr"
+version="115.20.0esr"
 application="firefox"
 ftpmirror="https://ftp.mozilla.org/pub/$application/releases/$version"
 

--- a/linux/build/preferences/distribution/policies.json
+++ b/linux/build/preferences/distribution/policies.json
@@ -87,10 +87,10 @@
       "UseProxyForDNS": true
     },
     "SearchBar": "unified",
-		"SearchEngines": {
-			"Default": "YaCy 'legwork'",
-			"Remove": ["Google"]
-		},
+    "SearchEngines": {
+      "Default": "YaCy 'legwork'",
+      "Remove": ["Google"]
+    },
     "SearchSuggestEnabled": false,
     "SupportMenu": {
       "Title": "Ilita IRC",

--- a/linux/build/preferences/distribution/policies.json
+++ b/linux/build/preferences/distribution/policies.json
@@ -87,6 +87,10 @@
       "UseProxyForDNS": true
     },
     "SearchBar": "unified",
+		"SearchEngines": {
+			"Default": "YaCy 'legwork'",
+			"Remove": ["Google"]
+		},
     "SearchSuggestEnabled": false,
     "SupportMenu": {
       "Title": "Ilita IRC",

--- a/linux/build/preferences/i2pdbrowser.cfg
+++ b/linux/build/preferences/i2pdbrowser.cfg
@@ -112,7 +112,7 @@ defaultPref("browser.search.order.US.2", "");
 defaultPref("browser.search.order.US.3", "");
 defaultPref("browser.search.redirectWindowsSearch", false);
 defaultPref("browser.search.region", "US");
-defaultPref("browser.search.searchEnginesURL", "");
+defaultPref("browser.search.engines.url", "http://legwork.i2p/yacysearch.html?query=");
 defaultPref("browser.search.suggest.enabled", false);
 defaultPref("browser.search.update", false);
 lockPref("browser.send_pings", false);

--- a/macos/build/build
+++ b/macos/build/build
@@ -12,8 +12,8 @@ cd $dir
 
 arch=$(uname -m)
 language=$(osascript -e 'user locale of (get system info)' | sed -e 's/_/-/g')
-version="115.19.0esr"
-i2pdversion="2.55.0"
+version="115.20.0esr"
+i2pdversion="2.56.0"
 
 ftpmirror="https://ftp.mozilla.org/pub/firefox/releases/${version}"
 

--- a/macos/build/preferences/distribution/policies.json
+++ b/macos/build/preferences/distribution/policies.json
@@ -87,10 +87,10 @@
       "UseProxyForDNS": true
     },
     "SearchBar": "unified",
-		"SearchEngines": {
-			"Default": "YaCy 'legwork'",
-			"Remove": ["Google"]
-		},
+    "SearchEngines": {
+      "Default": "YaCy 'legwork'",
+      "Remove": ["Google"]
+    },
     "SearchSuggestEnabled": false,
     "SupportMenu": {
       "Title": "Ilita IRC",

--- a/macos/build/preferences/distribution/policies.json
+++ b/macos/build/preferences/distribution/policies.json
@@ -87,6 +87,10 @@
       "UseProxyForDNS": true
     },
     "SearchBar": "unified",
+		"SearchEngines": {
+			"Default": "YaCy 'legwork'",
+			"Remove": ["Google"]
+		},
     "SearchSuggestEnabled": false,
     "SupportMenu": {
       "Title": "Ilita IRC",

--- a/macos/build/preferences/i2pdbrowser.cfg
+++ b/macos/build/preferences/i2pdbrowser.cfg
@@ -112,7 +112,7 @@ defaultPref("browser.search.order.US.2", "");
 defaultPref("browser.search.order.US.3", "");
 defaultPref("browser.search.redirectWindowsSearch", false);
 defaultPref("browser.search.region", "US");
-defaultPref("browser.search.searchEnginesURL", "");
+defaultPref("browser.search.engines.url", "http://legwork.i2p/yacysearch.html?query=");
 defaultPref("browser.search.suggest.enabled", false);
 defaultPref("browser.search.update", false);
 lockPref("browser.send_pings", false);

--- a/windows/build/build.cmd
+++ b/windows/build/build.cmd
@@ -7,8 +7,8 @@ REM See full license text in LICENSE file at top of project tree
 setlocal enableextensions
 
 set CURL=%~dp0curl.exe
-set FFversion=115.19.0esr
-set I2Pdversion=2.55.0
+set FFversion=115.20.0esr
+set I2Pdversion=2.56.0
 call :GET_LOCALE
 call :GET_PROXY
 call :GET_ARCH

--- a/windows/build/preferences/distribution/policies.json
+++ b/windows/build/preferences/distribution/policies.json
@@ -87,10 +87,10 @@
       "UseProxyForDNS": true
     },
     "SearchBar": "unified",
-		"SearchEngines": {
-			"Default": "YaCy 'legwork'",
-			"Remove": ["Google"]
-		},
+    "SearchEngines": {
+      "Default": "YaCy 'legwork'",
+      "Remove": ["Google"]
+    },
     "SearchSuggestEnabled": false,
     "SupportMenu": {
       "Title": "Ilita IRC",

--- a/windows/build/preferences/distribution/policies.json
+++ b/windows/build/preferences/distribution/policies.json
@@ -87,6 +87,10 @@
       "UseProxyForDNS": true
     },
     "SearchBar": "unified",
+		"SearchEngines": {
+			"Default": "YaCy 'legwork'",
+			"Remove": ["Google"]
+		},
     "SearchSuggestEnabled": false,
     "SupportMenu": {
       "Title": "Ilita IRC",

--- a/windows/build/preferences/i2pdbrowser.cfg
+++ b/windows/build/preferences/i2pdbrowser.cfg
@@ -112,7 +112,7 @@ defaultPref("browser.search.order.US.2", "");
 defaultPref("browser.search.order.US.3", "");
 defaultPref("browser.search.redirectWindowsSearch", false);
 defaultPref("browser.search.region", "US");
-defaultPref("browser.search.searchEnginesURL", "");
+defaultPref("browser.search.engines.url", "http://legwork.i2p/yacysearch.html?query=");
 defaultPref("browser.search.suggest.enabled", false);
 defaultPref("browser.search.update", false);
 lockPref("browser.send_pings", false);


### PR DESCRIPTION
This pull request updates Firefox ESR from version 115.19.0 to 115.20.0 and I2Pd from version 2.55.0 to 2.56.0. It also makes some changes to remove Google as the default search engine.