### PR TITLE
fix double-run requirement

### DIFF
--- a/windows/StartI2PdBrowser.bat
+++ b/windows/StartI2PdBrowser.bat
@@ -12,7 +12,7 @@ set fire=firefox.exe
 set port=FirefoxPortable.exe
 set i2pd=i2pd.exe
 
-if not exist Firefox ( echo Firefox not found... Start building... && cd build && call build.cmd )
+if not exist Firefox ( echo Firefox not found... Start building... && pushd build && call build.cmd --skipwait & popd )
 
 taskList|find /i "%port%">nul&&(taskkill /im "%port%" /t>nul)&&(%$pause% 2 >nul)
 REM taskList|find /i "%fire%">nul&&(taskkill /im "%fire%" >nul)

--- a/windows/build/build.cmd
+++ b/windows/build/build.cmd
@@ -1,6 +1,6 @@
 @echo off
 
-REM Copyright (c) 2013-2024, The PurpleI2P Project
+REM Copyright (c) 2013-2025, The PurpleI2P Project
 REM This file is part of Purple i2pd project and licensed under BSD3
 REM See full license text in LICENSE file at top of project tree
 
@@ -9,6 +9,7 @@ setlocal enableextensions
 set CURL=%~dp0curl.exe
 set FFversion=115.20.0esr
 set I2Pdversion=2.56.0
+call :GET_ARGS %*
 call :GET_LOCALE
 call :GET_PROXY
 call :GET_ARCH
@@ -147,8 +148,8 @@ if "%locale%"=="ru" (
 ) else (
 	echo I2Pd Browser Portable is ready to start!
 )
-pause
-exit
+if not defined arg_skipwait pause
+exit /b
 
 :GET_LOCALE
 for /f "tokens=3" %%a in ('reg query "HKEY_USERS\.DEFAULT\Keyboard Layout\Preload"^|find "REG_SZ"') do (
@@ -166,6 +167,13 @@ goto :eof
 :GET_ARCH
 set xOS=win32
 if defined PROCESSOR_ARCHITEW6432 (set xOS=win64) else if "%PROCESSOR_ARCHITECTURE%" neq "x86" (set xOS=win64)
+goto :eof
+
+:GET_ARGS
+set arg_skipwait=
+for %%a in (%*) do (
+	if "%%a"=="--skipwait" set arg_skipwait=yes
+)
 goto :eof
 
 :eof


### PR DESCRIPTION
- do not need to click StartI2PdBrowser.bat twice to run FF at initial startup
- added arguments support
- skip requirement to press ENTER when build successful and running with --skipwait