### PR TITLE
Improve downloading on Windows & i2pd version update

### DIFF
--- a/macos/build/build
+++ b/macos/build/build
@@ -13,7 +13,7 @@ cd $dir
 arch=$(uname -m)
 language=$(osascript -e 'user locale of (get system info)' | sed -e 's/_/-/g')
 version="115.20.0esr"
-i2pdversion="2.56.0"
+i2pdversion="2.59.0"
 
 ftpmirror="https://ftp.mozilla.org/pub/firefox/releases/${version}"
 

--- a/macos/build/build
+++ b/macos/build/build
@@ -13,7 +13,7 @@ cd $dir
 arch=$(uname -m)
 language=$(osascript -e 'user locale of (get system info)' | sed -e 's/_/-/g')
 version="115.20.0esr"
-i2pdversion="2.59.0"
+i2pdversion="2.60.0"
 
 ftpmirror="https://ftp.mozilla.org/pub/firefox/releases/${version}"
 

--- a/windows/StartI2PdBrowser.bat
+++ b/windows/StartI2PdBrowser.bat
@@ -1,18 +1,28 @@
 @ECHO OFF
-REM Copyright (c) 2013-2019, The PurpleI2P Project
+REM Copyright (c) 2013-2026, The PurpleI2P Project
 REM This file is part of Purple i2pd project and licensed under BSD3
 REM See full license text in LICENSE file at top of project tree
 
 title Starting I2Pd Browser
-set $pause=ping.exe 0.0.0.0 -n
-set $cd=%CD%
-ver| find "6." >nul && set $pause=timeout.exe /t
+setlocal enableextensions
 
+set $pause=ping.exe 0.0.0.0 -n
+ver| find "6." >nul && set $pause=timeout.exe /t
+ver| find "10.">nul && set $pause=timeout.exe /t
+set $cd=%~dp0
+set CURL=%~dp0build\curl.exe
 set fire=firefox.exe
 set port=FirefoxPortable.exe
 set i2pd=i2pd.exe
 
-if not exist Firefox ( echo Firefox not found... Start building... && pushd build && call build.cmd --skipwait & popd )
+:building
+cd /d "%$cd%"
+call :check_requirements || (
+	echo Start building...
+	pushd build
+	call build.cmd --skipwait
+	popd
+)
 
 taskList|find /i "%port%">nul&&(taskkill /im "%port%" /t>nul)&&(%$pause% 2 >nul)
 REM taskList|find /i "%fire%">nul&&(taskkill /im "%fire%" >nul)
@@ -22,10 +32,30 @@ taskList|find /i "%i2pd%">nul&&(goto runfox)||(goto starti2p)
 cd i2pd
 start "" "%i2pd%"
 
-echo i2pd Browser starting
+echo i2pd Router starting
 echo Please wait
 echo -------------------------------------
-for /L %%B in (0,1,35) do (call :EchoWithoutCrLf "." && %$pause% 2 >nul)
+set watchdog=0
+:wait_i2pd
+rem Checking for code 200 HTTP/OK
+"%CURL%" -s -x http://127.0.0.1:4444 -w "%%{http_code}\n" -o nul http://i2pd.i2p/ | find "200" || (
+	if not exist i2pd.exe (
+		if "%locale%"=="ru" (
+			echo Пожалуйста, нажмите ДА в окнах UAC чтобы добавить i2pd в иключения Защитника Windows
+		) else (
+			echo Please, press YES in UAC windows to add i2pd in Windows Defender exclusion
+		)
+		call :ADD_DEFENDER_EXCLUSION "%~dp0i2pd\i2pd.exe"
+		call :WARN_ANTIVIRUS
+		%$pause% 5
+		rem We need download i2pd again
+		goto building
+	)
+	call :EchoWithoutCrLf "." && %$pause% 1 >nul
+	set /a watchdog+=1
+	rem Maximum 5 minutes wait time
+	if %watchdog% lss 300 goto wait_i2pd
+)
 echo .
 echo -------------------------------------
 echo Welcome to I2P Network
@@ -35,18 +65,33 @@ cd %$cd%
 cd Firefox
 start "" "%port%"
 cd %$cd%
+%$pause% 5
 exit /b 0
 
+:check_requirements
+	if not exist Firefox ( echo Firefox not found... && exit /b 1 )
+	if not exist i2pd\i2pd.exe ( echo i2pd not found... && exit /b 1 )
+exit /b 0
 
-rem ==========================================================================
+rem Предупреждает о возможном вмешательстве антивируса
+rem Предлагает его отключить, открыв окно настроек Windows Defender
+:WARN_ANTIVIRUS
+if "%locale%"=="ru" (
+	echo Ошибка запуска i2pd. Убедитесь, что Windows Defender отключен.
+) else (
+	echo Error running i2pd. Make sure Windows Defender is disabled.
+)
+explorer.exe "WindowsDefender://ThreatSettings"
+goto :eof
 
-rem ==========================================================================
-rem ╧ЁюЎхфєЁр EchoWithoutCrLf
-rem
-rem %1 : ЄхъёЄ фы  т√тюфр.
-rem ==========================================================================
+rem Добавляет в исключения WD переданный аргументом объект (вызывает окно UAC)
+rem %1 : файл для добавления в исключения Защитника Windows
+:ADD_DEFENDER_EXCLUSION
+powershell start -verb runas powershell -ArgumentList 'Add-MpPreference -Force -ExclusionPath "%~1"'
+goto :eof
+
+rem Процедура EchoWithoutCrLf
+rem %1 : текст для вывода.
 :EchoWithoutCrLf
-
-    <nul set /p strTemp=%~1
-    exit /b 0
-rem ==========================================================================
+<nul set /p strTemp=%~1
+exit /b 0

--- a/windows/StartI2PdBrowser.bat
+++ b/windows/StartI2PdBrowser.bat
@@ -38,7 +38,7 @@ echo -------------------------------------
 set watchdog=0
 :wait_i2pd
 rem Checking for code 200 HTTP/OK
-"%CURL%" -s -x http://127.0.0.1:4444 -w "%%{http_code}\n" -o nul http://i2pd.i2p/ | find "200" || (
+"%CURL%" -s -x http://127.0.0.1:4444 -w "%%{http_code}\n" -o nul http://shx5vqsw7usdaunyzr2qmes2fq37oumybpudrd4jjj4e4vk4uusa.b32.i2p/ | find "200" || (
 	if not exist i2pd.exe (
 		if "%locale%"=="ru" (
 			echo Пожалуйста, нажмите ДА в окнах UAC чтобы добавить i2pd в иключения Защитника Windows

--- a/windows/build/build.cmd
+++ b/windows/build/build.cmd
@@ -8,7 +8,7 @@ setlocal enableextensions
 
 set CURL=%~dp0curl.exe
 set FFversion=115.20.0esr
-set I2Pdversion=2.59.0
+set I2Pdversion=2.60.0
 
 call :GET_ARGS %*
 call :GET_LOCALE


### PR DESCRIPTION
 - Update i2pd to version 2.59.0
 - Replace timer by HTTP/OK check before running FF
 - Add into Windows Defender exclusion (Fixes https://github.com/PurpleI2P/i2pdbrowser/issues/75)
 - Re-run build when WD killed the i2pd
 - Retry download on fail
 - Better integrity check
 - Skip ssl certificate validation (Fixes https://github.com/PurpleI2P/i2pdbrowser/issues/85)
 - Fix other minor issues